### PR TITLE
Revert "tcp: do not lock listener to process SYN packets"

### DIFF
--- a/net/ipv4/tcp_ipv4.c
+++ b/net/ipv4/tcp_ipv4.c
@@ -1801,7 +1801,7 @@ static __sum16 tcp_v4_checksum_init(struct sk_buff *skb)
 
 
 /* The socket must have it's spinlock held when we get
- * here, unless it is a TCP_LISTEN socket.
+ * here.
  *
  * We have a potential double-lock case here, so even when
  * doing backlog processing we use the BH locking scheme.
@@ -2049,11 +2049,6 @@ process:
 
 	skb->dev = NULL;
 
-	if (sk->sk_state == TCP_LISTEN) {
-		ret = tcp_v4_do_rcv(sk, skb);
-		goto put_and_return;
-	}
-
 	bh_lock_sock_nested(sk);
 	ret = 0;
 	if (!sock_owned_by_user(sk)) {
@@ -2077,7 +2072,6 @@ process:
 	}
 	bh_unlock_sock(sk);
 
-put_and_return:
 	sock_put(sk);
 
 	return ret;

--- a/net/ipv6/tcp_ipv6.c
+++ b/net/ipv6/tcp_ipv6.c
@@ -1316,7 +1316,7 @@ static __sum16 tcp_v6_checksum_init(struct sk_buff *skb)
 }
 
 /* The socket must have it's spinlock held when we get
- * here, unless it is a TCP_LISTEN socket.
+ * here.
  *
  * We have a potential double-lock case here, so even when
  * doing backlog processing we use the BH locking scheme.
@@ -1523,11 +1523,6 @@ process:
 
 	skb->dev = NULL;
 
-	if (sk->sk_state == TCP_LISTEN) {
-		ret = tcp_v6_do_rcv(sk, skb);
-		goto put_and_return;
-	}
-
 	bh_lock_sock_nested(sk);
 	ret = 0;
 	if (!sock_owned_by_user(sk)) {
@@ -1551,7 +1546,6 @@ process:
 	}
 	bh_unlock_sock(sk);
 
-put_and_return:
 	sock_put(sk);
 	return ret ? -1 : 0;
 


### PR DESCRIPTION
This commit belongs to the patch set (https://lwn.net/Articles/659199/) that attempts to remove the use of locks on the socket table by relocating the SYN table to a separate hash table and adding a spin lock to protect the SYN request queue.   Adding only this commit introduces a race condition for Linux 3.10 kernels for TCP listens, since the TCP SYN data structures can be corrupted.

In other words, this commit only works with the other commits added to it - why it was added in isolation is a mystery.  Are there other forks that should include this revert?

```
  tcp: add a spinlock to protect struct request_sock_queue
  tcp: move qlen/young out of struct listen_sock
  tcp: move synflood_warned into struct request_sock_queue
  tcp: call sk_mark_napi_id() on the child, not the listener
  tcp/dccp: init sk_prot and call sk_node_init() in reqsk_alloc()
  tcp: cleanup tcp_v[46]_inbound_md5_hash()
  tcp: remove BUG_ON() in tcp_check_req()
  tcp: get_openreq[46]() changes
  tcp/dccp: remove inet_csk_reqsk_queue_added() timeout argument
  tcp/dccp: install syn_recv requests into ehash table
  tcp/dccp: shrink struct listen_sock
  ipv6: remove obsolete inet6 functions
  tcp: attach SYNACK messages to request sockets instead of listener
  tcp/dccp: remove struct listen_sock
  tcp: remove max_qlen_log
  tcp/dccp: add a reschedule point in inet_csk_listen_stop()
```

Cross-compiling https://github.com/tinyproxy/tinyproxy for Android, the SYN Recv queue can be corrupted otherwise:
```
for i in $(seq 1 400); do curl -x localhost:443 https://myhost.com.com -L  --connect-timeout 30 -o /dev/null -sS & done
```

Check:

```
ss -nltp
```

Expect: ACK backlog to drop to 0.  With enough requests, we see no further connections allowed.

This reverts commit 8664001fe2ab84c31d6d04097cd029cf1f8ab25a.

